### PR TITLE
Add a python function for calling the MSFT FHIR Converter CLI tool an…

### DIFF
--- a/cloud-run/fhir-converter/FHIR-Converter-Installation-And-Usage-Guide.md
+++ b/cloud-run/fhir-converter/FHIR-Converter-Installation-And-Usage-Guide.md
@@ -1,0 +1,50 @@
+# Microsoft FHIR Converter CLI Installation Guide
+This document provides a guide for installing the [Microsoft FHIR Converter](https://github.com/microsoft/FHIR-Converter) as a Command Line Interface (CLI) tool on MacOS and Linux (*.nix) systems and a brief introduction to using the converter.
+
+## Install the .NET Framework
+We will use .NET to build the FHIR Converter from source code. Follow the steps to below to install .NET. If .NET is already installed skip to [Download and Build the FHIR Converter](#download-and-build-the-fhir-converter). To check if .NET is installed trying running `dotnet`, if documentation about using .NET is displayed then it is installed. A response indicating that the command was not found suggests that .NET is not installed.  
+
+### Download the .NET Install Script
+Run `wget https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh` to download the .NET installation script from Microsoft.
+
+### Install .NET
+From the directory containing the `dotnet-install.sh` file, downloaded in the previous step, run `sh ./dotnet-install.sh` to execute the script and install .NET.
+
+### Add .NET to the PATH Environment Variable
+Finally, add .NET to you PATH variable by running `export PATH="$PATH:$HOME/.dotnet"`.
+
+### Confirm That .NET has Been Installed.
+Restart your shell with `exec $SHELL` and then run `dotnet`. If you get a response that looks like what is shown below, .NET was installed successfully.
+
+>Usage: dotnet [options]
+>Usage: dotnet [path-to-application]
+>
+>Options:  
+>  -h|--help         Display help.  
+>  --info            Display .NET Core information.  
+>  --list-sdks       Display the installed SDKs.  
+>  --list-runtimes   Display the installed runtimes.  
+>
+>path-to-application:  
+>  The path to an application .dll file to execute.  
+
+## Download and Build the FHIR Converter
+
+### Get Microsoft FHIR Converter
+Clone the Microsfot FHIR Converter source code from GitHub with a command like this one that downloads the 5.0.4 release (most recent at the time of writing). 
+`git clone https://github.com/microsoft/FHIR-Converter/tree/v5.0.4 --single-branch`
+
+### Build the FHIR Converter Tool
+Navigate to `.../FHIR-Converter/src/Microsoft.Health.Fhir.Liquid.Converter.Tool` and run `dotnet build` to build the FHIR Converter. 
+
+## Using the FHIR Converter
+
+Two examples have been provided below of using the FHIR Converter via the `dotnet run` function. Please note that `--` is used to deliminate between arguments that should be passed to `dotnet` as opposed arguments that `dotnet` should be pass to the application, in this case the FHIR Converter, that it is  being used to run. Additionaly, the `-p` option is only required when not calling `dotnet run` from the `FHIR-Converter/src/Health.Fhir.Liquid.Converter.Tool/` directory. For additional information on `dotnet run` please refer to [this documentation from Microsoft](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-run).
+
+### Message in File to FHIR
+The following command can be used to convert a message from a file to FHIR.
+`dotnet run convert -p path-to-Microsoft.Health.Fhir.Liquid.Converter.Tool/ -- -d path-to-template subdirectory-for-message-type -r root-template -n path-to-file-to-be-converted -f path-to-output`
+
+### Covert Message Content Directory to FHIR
+The following command can be used to convert the contents of a message provided directly as a string to FHIR.
+`dotnet run convert -p path-to-Microsoft.Health.Fhir.Liquid.Converter.Tool/ -- -d path-to-template subdirectory-for-message-type -r root-template -c message-content -f path-to-output`

--- a/cloud-run/fhir-converter/main.py
+++ b/cloud-run/fhir-converter/main.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Union, Optional
-import logging
 import subprocess
 import json
 
@@ -62,9 +61,9 @@ def convert_to_fhir(
 
     # Forumlate command for the FHIR Converter.
     fhir_conversion_command = [
-        f"dotnet run ",
+        "dotnet run ",
         f"--project {str(converter_project_path)} ",
-        f"convert -- ",
+        "convert -- ",
         f"--TemplateDirectory {str(template_directory_path)} ",
         f"--RootTemplate {root_template} ",
         f"--OutputDataFile {str(output_data_file_path)} ",

--- a/cloud-run/fhir-converter/main.py
+++ b/cloud-run/fhir-converter/main.py
@@ -62,7 +62,7 @@ def convert_to_fhir(
 
     # Forumlate command for the FHIR Converter.
     fhir_conversion_command = [
-        f"dotnet run ", 
+        f"dotnet run ",
         f"--project {str(converter_project_path)} ",
         f"convert -- ",
         f"--TemplateDirectory {str(template_directory_path)} ",
@@ -76,7 +76,7 @@ def convert_to_fhir(
         fhir_conversion_command.append(f"--InputDataFile {str(input_data_file_path)}")
 
     fhir_conversion_command = "".join(fhir_conversion_command)
-    
+
     # Call the FHIR Converter.
     converter_response = subprocess.run(
         fhir_conversion_command, shell=True, capture_output=True
@@ -89,20 +89,3 @@ def convert_to_fhir(
         result = vars(converter_response)
 
     return result
-
-
-if __name__ == "__main__":
-    template_directory_path = "/Users/danielpaseltiner/docker-msft-fhir-converter/FHIR-Converter/data/Templates/Ccda"
-    root_template = "CCD"
-    input_data_file_path = "/Users/danielpaseltiner/docker-msft-fhir-converter/FHIR-Converter/data/SampleData/Ccda/Patient-1.ccda"
-    output_data_file_path = "/Users/danielpaseltiner/docker-msft-fhir-converter/test.fhir"
-    converter_project_path = "/Users/danielpaseltiner/docker-msft-fhir-converter/FHIR-Converter/src/Microsoft.Health.Fhir.Liquid.Converter.Tool"
-    
-    result = convert_to_fhir(
-        output_data_file_path,
-        template_directory_path,
-        converter_project_path,
-        root_template,
-        input_data_content=Path(input_data_file_path).read_text(),
-    )
-    print(result)

--- a/cloud-run/fhir-converter/main.py
+++ b/cloud-run/fhir-converter/main.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+from typing import Union, Optional
+import logging
+import subprocess
+import json
+
+
+def convert_to_fhir(
+    output_data_file_path: Union[str, Path],
+    template_directory_path: Union[str, Path],
+    converter_project_path: Union[str, Path],
+    root_template: str,
+    input_data_content: Optional[str] = None,
+    input_data_file_path: Optional[Union[str, Path]] = None,
+) -> dict:
+    """
+    Call the Microsoft FHIR Converter CLI tool to convert an Hl7v2, or C-CDA message
+    to FHIR R4. The message to be converted can be provided either as a string via the
+    input_data_content argument, or by specifying a path to a file containing the
+    message with input_data_file_path. One, but not both of these parameters is
+    required. When conversion is successfull a dictionary containing the resulting FHIR
+    bundle is returned. When conversion fails a dictionary containing the response from
+    the FHIR Converter is returned. In order to successfully call this function,
+    the conversion tool must be installed. For information on how to do this please
+    refer to FHIR-Converter-Installation-And-Usage-Guide. The source code for the
+    converter can be found at https://github.com/microsoft/FHIR-Converter.
+
+    :param output_file_path: The complete path for the output file containing the FHIR
+        bundle produced by the conversion.
+    :param template_directory_path: Path to the Templates/ subdirectory within the FHIR
+        Converter for data type to be converted (Ccda/, Hl7v2/, Json/, or Stu3ToR4/).
+    :param converter_project_path: Path to the
+        Microsoft.Health.Fhir.Liquid.Converter.Tool/ directory within the FHIR
+        converter.
+    :param root_template: Name of the liquid template within the template_direcotry_path
+        to be used for conversion, excluding the '.liquid' extension. Options are listed
+        in the FHIR-Converter README.md.
+    :param input_data_content: The message to be converted as a string.
+    :param input_data_file_path: The complete path to a file containing a single message
+        to convert to FHIR.
+    """
+
+    # Ensure either input_data_content or input_data_file_path has been provided.
+    if input_data_content is None and input_data_file_path is None:
+        raise ValueError(
+            "A value for input_data_content or input_data_file_path must be provided."
+        )
+    if input_data_content is not None and input_data_file_path is not None:
+        raise ValueError(
+            "Both input_data_content or input_data_file_path cannot be specified. "
+        )
+
+    # Ensure all paths are pathlib objects not strings.
+    for path in [
+        input_data_file_path,
+        output_data_file_path,
+        template_directory_path,
+        converter_project_path,
+    ]:
+        if type(path) == str:
+            path = Path(path)
+
+    # Forumlate command for the FHIR Converter.
+    fhir_conversion_command = [
+        f"dotnet run ", 
+        f"--project {str(converter_project_path)} ",
+        f"convert -- ",
+        f"--TemplateDirectory {str(template_directory_path)} ",
+        f"--RootTemplate {root_template} ",
+        f"--OutputDataFile {str(output_data_file_path)} ",
+    ]
+
+    if input_data_content is not None:
+        fhir_conversion_command.append(f"--InputDataContent $'{input_data_content}'")
+    else:
+        fhir_conversion_command.append(f"--InputDataFile {str(input_data_file_path)}")
+
+    fhir_conversion_command = "".join(fhir_conversion_command)
+    
+    # Call the FHIR Converter.
+    converter_response = subprocess.run(
+        fhir_conversion_command, shell=True, capture_output=True
+    )
+
+    # Process the response from FHIR Converter.
+    if converter_response.returncode == 0:
+        result = json.load(open(output_data_file_path))
+    else:
+        result = vars(converter_response)
+
+    return result
+
+
+if __name__ == "__main__":
+    template_directory_path = "/Users/danielpaseltiner/docker-msft-fhir-converter/FHIR-Converter/data/Templates/Ccda"
+    root_template = "CCD"
+    input_data_file_path = "/Users/danielpaseltiner/docker-msft-fhir-converter/FHIR-Converter/data/SampleData/Ccda/Patient-1.ccda"
+    output_data_file_path = "/Users/danielpaseltiner/docker-msft-fhir-converter/test.fhir"
+    converter_project_path = "/Users/danielpaseltiner/docker-msft-fhir-converter/FHIR-Converter/src/Microsoft.Health.Fhir.Liquid.Converter.Tool"
+    
+    result = convert_to_fhir(
+        output_data_file_path,
+        template_directory_path,
+        converter_project_path,
+        root_template,
+        input_data_content=Path(input_data_file_path).read_text(),
+    )
+    print(result)

--- a/cloud-run/fhir-converter/requirements.txt
+++ b/cloud-run/fhir-converter/requirements.txt
@@ -1,0 +1,15 @@
+anyio==3.6.1
+attrs==22.1.0
+fastapi==0.79.0
+idna==3.3
+iniconfig==1.1.1
+packaging==21.3
+pluggy==1.0.0
+py==1.11.0
+pydantic==1.9.1
+pyparsing==3.0.9
+pytest==7.1.2
+sniffio==1.2.0
+starlette==0.19.1
+tomli==2.0.1
+typing_extensions==4.3.0

--- a/cloud-run/fhir-converter/test_FHIR-Converter.py
+++ b/cloud-run/fhir-converter/test_FHIR-Converter.py
@@ -1,0 +1,74 @@
+from unittest import mock
+import pytest
+from main import convert_to_fhir
+
+@mock.patch("main.vars")
+@mock.patch("main.json.load")
+@mock.patch("main.open")
+@mock.patch("main.subprocess.run")
+def test_convert_to_fhir(patched_subprocess_run, patched_open, patched_json_load, patched_vars):
+
+    # Prep dummy arguments values.
+    template_directory_path = "my/path/to/Templates/subdirectory"
+    root_template = "my-root-template"
+    input_data_content = "my-message-content"
+    input_data_file_path = "my/path/to/input/data/file"
+    output_data_file_path = "my/path/to/output/data/file"
+    converter_project_path = "my/path/to/converter/project"
+
+    base_fhir_conversion_command = [
+    f"dotnet run ", 
+    f"--project {converter_project_path} ",
+    f"convert -- ",
+    f"--TemplateDirectory {template_directory_path} ",
+    f"--RootTemplate {root_template} ",
+    f"--OutputDataFile {output_data_file_path} ",
+    ]
+    
+    # Provide source data content directly with succesfull conversion.
+    patched_subprocess_run.return_value = mock.Mock(returncode=0)
+    result = convert_to_fhir(
+        output_data_file_path,
+        template_directory_path,
+        converter_project_path,
+        root_template,
+        input_data_content=input_data_content,
+    )
+    fhir_conversion_command = "".join(base_fhir_conversion_command) + f"--InputDataContent $'{input_data_content}'"
+    patched_subprocess_run.assert_called_with(fhir_conversion_command, shell=True, capture_output=True)
+    patched_open.assert_called_with(output_data_file_path)
+
+    # Provide file containing source data with unsuccesfull conversion.
+    patched_subprocess_run.return_value = mock.Mock(returncode=1)
+    result = convert_to_fhir(
+        output_data_file_path,
+        template_directory_path,
+        converter_project_path,
+        root_template,
+        input_data_file_path=input_data_file_path,
+    )
+    fhir_conversion_command = "".join(base_fhir_conversion_command) + f"--InputDataFile {input_data_file_path}"
+    patched_subprocess_run.assert_called_with(fhir_conversion_command, shell=True, capture_output=True)
+    patched_vars.assert_called()
+
+    # Ensure ValueError is reaised when neither input_data_content or 
+    # input_data_file_path are provided.
+    with pytest.raises(ValueError):
+        convert_to_fhir(
+        output_data_file_path,
+        template_directory_path,
+        converter_project_path,
+        root_template,
+        )
+
+    # Ensure ValueError is reaised when both input_data_content or input_data_file_path 
+    # are provided.
+    with pytest.raises(ValueError):
+        convert_to_fhir(
+        output_data_file_path,
+        template_directory_path,
+        converter_project_path,
+        root_template,
+        input_data_content=input_data_content,
+        input_data_file_path=input_data_file_path,
+        )     

--- a/cloud-run/fhir-converter/test_FHIR-Converter.py
+++ b/cloud-run/fhir-converter/test_FHIR-Converter.py
@@ -20,9 +20,9 @@ def test_convert_to_fhir(
     converter_project_path = "my/path/to/converter/project"
 
     base_fhir_conversion_command = [
-        f"dotnet run ",
+        "dotnet run ",
         f"--project {converter_project_path} ",
-        f"convert -- ",
+        "convert -- ",
         f"--TemplateDirectory {template_directory_path} ",
         f"--RootTemplate {root_template} ",
         f"--OutputDataFile {output_data_file_path} ",
@@ -30,7 +30,7 @@ def test_convert_to_fhir(
 
     # Provide source data content directly with succesfull conversion.
     patched_subprocess_run.return_value = mock.Mock(returncode=0)
-    result = convert_to_fhir(
+    convert_to_fhir(
         output_data_file_path,
         template_directory_path,
         converter_project_path,
@@ -48,7 +48,7 @@ def test_convert_to_fhir(
 
     # Provide file containing source data with unsuccesfull conversion.
     patched_subprocess_run.return_value = mock.Mock(returncode=1)
-    result = convert_to_fhir(
+    convert_to_fhir(
         output_data_file_path,
         template_directory_path,
         converter_project_path,

--- a/cloud-run/fhir-converter/test_FHIR-Converter.py
+++ b/cloud-run/fhir-converter/test_FHIR-Converter.py
@@ -2,11 +2,14 @@ from unittest import mock
 import pytest
 from main import convert_to_fhir
 
+
 @mock.patch("main.vars")
 @mock.patch("main.json.load")
 @mock.patch("main.open")
 @mock.patch("main.subprocess.run")
-def test_convert_to_fhir(patched_subprocess_run, patched_open, patched_json_load, patched_vars):
+def test_convert_to_fhir(
+    patched_subprocess_run, patched_open, patched_json_load, patched_vars
+):
 
     # Prep dummy arguments values.
     template_directory_path = "my/path/to/Templates/subdirectory"
@@ -17,14 +20,14 @@ def test_convert_to_fhir(patched_subprocess_run, patched_open, patched_json_load
     converter_project_path = "my/path/to/converter/project"
 
     base_fhir_conversion_command = [
-    f"dotnet run ", 
-    f"--project {converter_project_path} ",
-    f"convert -- ",
-    f"--TemplateDirectory {template_directory_path} ",
-    f"--RootTemplate {root_template} ",
-    f"--OutputDataFile {output_data_file_path} ",
+        f"dotnet run ",
+        f"--project {converter_project_path} ",
+        f"convert -- ",
+        f"--TemplateDirectory {template_directory_path} ",
+        f"--RootTemplate {root_template} ",
+        f"--OutputDataFile {output_data_file_path} ",
     ]
-    
+
     # Provide source data content directly with succesfull conversion.
     patched_subprocess_run.return_value = mock.Mock(returncode=0)
     result = convert_to_fhir(
@@ -34,8 +37,13 @@ def test_convert_to_fhir(patched_subprocess_run, patched_open, patched_json_load
         root_template,
         input_data_content=input_data_content,
     )
-    fhir_conversion_command = "".join(base_fhir_conversion_command) + f"--InputDataContent $'{input_data_content}'"
-    patched_subprocess_run.assert_called_with(fhir_conversion_command, shell=True, capture_output=True)
+    fhir_conversion_command = (
+        "".join(base_fhir_conversion_command)
+        + f"--InputDataContent $'{input_data_content}'"
+    )
+    patched_subprocess_run.assert_called_with(
+        fhir_conversion_command, shell=True, capture_output=True
+    )
     patched_open.assert_called_with(output_data_file_path)
 
     # Provide file containing source data with unsuccesfull conversion.
@@ -47,28 +55,33 @@ def test_convert_to_fhir(patched_subprocess_run, patched_open, patched_json_load
         root_template,
         input_data_file_path=input_data_file_path,
     )
-    fhir_conversion_command = "".join(base_fhir_conversion_command) + f"--InputDataFile {input_data_file_path}"
-    patched_subprocess_run.assert_called_with(fhir_conversion_command, shell=True, capture_output=True)
+    fhir_conversion_command = (
+        "".join(base_fhir_conversion_command)
+        + f"--InputDataFile {input_data_file_path}"
+    )
+    patched_subprocess_run.assert_called_with(
+        fhir_conversion_command, shell=True, capture_output=True
+    )
     patched_vars.assert_called()
 
-    # Ensure ValueError is reaised when neither input_data_content or 
+    # Ensure ValueError is reaised when neither input_data_content or
     # input_data_file_path are provided.
     with pytest.raises(ValueError):
         convert_to_fhir(
-        output_data_file_path,
-        template_directory_path,
-        converter_project_path,
-        root_template,
+            output_data_file_path,
+            template_directory_path,
+            converter_project_path,
+            root_template,
         )
 
-    # Ensure ValueError is reaised when both input_data_content or input_data_file_path 
+    # Ensure ValueError is reaised when both input_data_content or input_data_file_path
     # are provided.
     with pytest.raises(ValueError):
         convert_to_fhir(
-        output_data_file_path,
-        template_directory_path,
-        converter_project_path,
-        root_template,
-        input_data_content=input_data_content,
-        input_data_file_path=input_data_file_path,
-        )     
+            output_data_file_path,
+            template_directory_path,
+            converter_project_path,
+            root_template,
+            input_data_content=input_data_content,
+            input_data_file_path=input_data_file_path,
+        )


### PR DESCRIPTION
This PR introduces:

1. A Python function that calls the Microsoft FHIR Converter CLI tool 
2. Documentation for installing the FHIR Converter on *nix systems which will need to be expanded to include instructions for Windows.
3. Establishes a `cloud-run/` directory with a `FHIR-Converter` subdirectory that will eventually contain the source code for a containerized service implementation of the FHIR Converter CLI tool.
