### PR TITLE
Fix 'ccda' and 'c-cda' inconsistencies.

### DIFF
--- a/cloud-run/fhir-converter/main.py
+++ b/cloud-run/fhir-converter/main.py
@@ -135,11 +135,11 @@ def convert_to_fhir(
     )
     if input_type == "hl7v2":
         template_directory_path = "/build/FHIR-Converter/data/Templates/Hl7v2"
-    elif input_type == "c-cda":
+    elif input_type == "ccda":
         template_directory_path = "/build/FHIR-Converter/data/Templates/Ccda"
     else:
         raise ValueError(
-            f"Invalid input_type {input_type}. Valid values are 'hl7v2' and 'c-cda'."
+            f"Invalid input_type {input_type}. Valid values are 'hl7v2' and 'ccda'."
         )
     output_data_file_path = "/tmp/output.json"
 


### PR DESCRIPTION
This resolves inconsistencies in our use of "ccda" and "c-cda". Previously, use of "ccda" for `input_type` would result in an exception from the `convert-to-fhir()` function while use of "c-cda" would result in an exception from Pydantic validation of the InputType class. This PR standardizes on use of "ccda", which aligns with the Microsoft FHIR converter, allowing us to convert CCDA data. 