### PR TITLE
Build MSFT FHIR Converter from its root directory.

### DIFF
--- a/cloud-run/fhir-converter/Dockerfile
+++ b/cloud-run/fhir-converter/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh | \
 # Download FHIR-Converter
 WORKDIR /build
 RUN git clone https://github.com/microsoft/FHIR-Converter.git --branch v5.0.4 --single-branch
-WORKDIR /build/FHIR-Converter/src/Microsoft.Health.Fhir.Liquid.Converter.Tool
+WORKDIR /build/FHIR-Converter
 
 # Build Microsoft FHIR Converter binary. Need to run twice due to strange error copying oras.exe
 RUN dotnet build || true


### PR DESCRIPTION
Small PR that aligns our installation of the Microsoft FHIR Converter with our installation guide.