### PR TITLE
Add Terraform configuration to enable GCP APIs

### DIFF
--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -6,7 +6,7 @@ provider "google" {
 
 resource "google_project_service" "enable_google_apis" {
   count   = length(var.gcp_services_list)
-  project = google_project.this.project_id
+  project = var.project_id
   service = var.gcp_services_list[count.index]
 
   disable_dependent_services = true

--- a/terraform/implementation/main.tf
+++ b/terraform/implementation/main.tf
@@ -4,6 +4,14 @@ provider "google" {
   zone    = var.zone
 }
 
+resource "google_project_service" "enable_google_apis" {
+  count   = length(var.gcp_services_list)
+  project = google_project.this.project_id
+  service = var.gcp_services_list[count.index]
+
+  disable_dependent_services = true
+}
+
 module "storage" {
   source     = "../modules/storage"
   project_id = var.project_id

--- a/terraform/implementation/variables.tf
+++ b/terraform/implementation/variables.tf
@@ -39,7 +39,6 @@ variable "gcp_services_list" {
     "run.googleapis.com",
     "servicemanagement.googleapis.com",
     "serviceusage.googleapis.com",
-    "source.googleapis.com",
     "sql-component.googleapis.com",
     "storage-api.googleapis.com",
     "storage-component.googleapis.com",

--- a/terraform/implementation/variables.tf
+++ b/terraform/implementation/variables.tf
@@ -11,3 +11,40 @@ variable "zone" {
   description = "value of the GCP zone to deploy to"
   default     = "us-east1-b"
 }
+
+variable "gcp_services_list" {
+  description = "The list of GCP APIs necessary for the project."
+  type        = list(string)
+  default = [
+    "artifactregistry.googleapis.com",
+    "bigquery.googleapis.com",
+    "bigquerymigration.googleapis.com",
+    "bigquerystorage.googleapis.com",
+    "cloudapis.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "clouddebugger.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "cloudtrace.googleapis.com",
+    "compute.googleapis.com",
+    "containerregistry.googleapis.com",
+    "datastore.googleapis.com",
+    "dns.googleapis.com",
+    "eventarc.googleapis.com",
+    "healthcare.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "oslogin.googleapis.com",
+    "pubsub.googleapis.com",
+    "run.googleapis.com",
+    "servicemanagement.googleapis.com",
+    "serviceusage.googleapis.com",
+    "source.googleapis.com",
+    "sql-component.googleapis.com",
+    "storage-api.googleapis.com",
+    "storage-component.googleapis.com",
+    "storage.googleapis.com",
+    "workflowexecutions.googleapis.com",
+    "workflows.googleapis.com"
+  ]
+}


### PR DESCRIPTION
Resolves [CU-2rrdc0d](https://app.clickup.com/t/2rrdc0d)

To get this list, I just ran `gcloud services list --enabled`. We can add to the variable list whenever we enable a new API.