### PR TITLE
Adds 'serviceusage.googleapis.com' to enabled services

### DIFF
--- a/quick-start.ps1
+++ b/quick-start.ps1
@@ -53,7 +53,8 @@ gcloud services enable `
     iam.googleapis.com `
     cloudresourcemanager.googleapis.com `
     iamcredentials.googleapis.com `
-    sts.googleapis.com
+    sts.googleapis.com `
+    serviceusage.googleapis.com
 
 # Create a service account
 gcloud iam service-accounts create "github" --project "$PROJECT_ID" --display-name "github"


### PR DESCRIPTION
# Description
I forgot to add the `serviceusage.googleapis.com` service in the Powershell script after merging the `main` branch into the `.sh` script.