### PR TITLE
Use GitHub CLI in quick-start scripts to set repository secrets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ To deploy this pipeline to your own Google Cloud environment, follow these steps
   
   Be sure to replace all instances of `myuser` in GitHub URLs with your user or organization name.
   1. [Install the gcloud CLI](https://cloud.google.com/sdk/docs/install-sdk)
+  1. [Install the GitHub CLI](https://cli.github.com/manual/installation) (optional)
   1. [Fork this repository](https://github.com/myuser/phdi-google-cloud/fork) into your personal or organization account
   1. Clone your newly forked repository to your local machine by running:
 


### PR DESCRIPTION
Resolves https://app.clickup.com/t/3cq8zdj

This updates both quick start scripts to use the GitHub CLI to set secrets automatically. @bryan-skylight could you test out the Powershell version on your local? Here's a success of the bash version:

<img width="2032" alt="Screen Shot 2022-08-29 at 10 23 20 AM" src="https://user-images.githubusercontent.com/9121162/187261645-165bd45c-9ca5-45e8-bff2-460cf601e156.png">
