### PR TITLE
Added multi regional storage class to all storage buckets

### DIFF
--- a/terraform/modules/google-workflows/main.tf
+++ b/terraform/modules/google-workflows/main.tf
@@ -12,8 +12,8 @@ resource "google_workflows_workflow" "workflow-1" {
 }
 
 resource "google_eventarc_trigger" "toy-bucket-new-file" {
-  name     = "phdi-${terraform.workspace}-toy-bucket-new-file"
-  location = "us"
+  name          = "phdi-${terraform.workspace}-toy-bucket-new-file"
+  location      = "us"
   matching_criteria {
     attribute = "type"
     value     = "google.cloud.storage.object.v1.finalized"

--- a/terraform/modules/google-workflows/main.tf
+++ b/terraform/modules/google-workflows/main.tf
@@ -12,8 +12,8 @@ resource "google_workflows_workflow" "workflow-1" {
 }
 
 resource "google_eventarc_trigger" "toy-bucket-new-file" {
-  name          = "phdi-${terraform.workspace}-toy-bucket-new-file"
-  location      = "us"
+  name     = "phdi-${terraform.workspace}-toy-bucket-new-file"
+  location = "us"
   matching_criteria {
     attribute = "type"
     value     = "google.cloud.storage.object.v1.finalized"

--- a/terraform/modules/storage/main.tf
+++ b/terraform/modules/storage/main.tf
@@ -5,6 +5,7 @@ resource "google_storage_bucket" "toybucket" {
   versioning {
     enabled = true
   }
+  storage_class = "MULTI_REGIONAL"
 }
 
 resource "google_storage_bucket" "phi_storage_bucket" {
@@ -14,6 +15,7 @@ resource "google_storage_bucket" "phi_storage_bucket" {
   versioning {
     enabled = true
   }
+  storage_class = "MULTI_REGIONAL"
 }
 
 resource "google_storage_bucket" "functions" {
@@ -23,6 +25,7 @@ resource "google_storage_bucket" "functions" {
   versioning {
     enabled = true
   }
+  storage_class = "MULTI_REGIONAL"
 }
 
 data "archive_file" "upcase_source" {

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -18,4 +18,5 @@ resource "google_storage_bucket" "tfstate" {
   name          = "phdi-tfstate-${var.project_id}"
   force_destroy = true
   location      = "US"
+  storage_class = "MULTI_REGIONAL"
 }


### PR DESCRIPTION
This is intended to provide Geo Redundant storage.  Per Google documentation: "All Cloud Storage data is redundant across at least two [zones](https://cloud.google.com/docs/geography-and-regions#regions_and_zones) within at least one geographic place as soon as you upload it.

Additionally, objects stored in a multi-region or dual-region are geo-redundant. Objects that are geo-redundant are stored redundantly in at least two separate geographic places separated by at least 100 miles."

https://cloud.google.com/storage/docs/locations