### PR TITLE
Added 'official' to the patient.name.use for our test cases

### DIFF
--- a/cloud-functions/phdi_cloud_function_utils/phdi_cloud_function_utils/single_patient_bundle.json
+++ b/cloud-functions/phdi_cloud_function_utils/phdi_cloud_function_utils/single_patient_bundle.json
@@ -14,7 +14,8 @@
                         "family": "Smith",
                         "given": [
                             "DeeDee"
-                        ]
+                        ],
+                        "use": "official"
                     }
                 ],
                 "gender": "female",


### PR DESCRIPTION
The latest version of the PHDI SDK will only pull the patient name where the use = 'official', to get test cases to pass we need to have that set properly.