### PR TITLE
Optimize fhir-converter Dockerfile

### DIFF
--- a/cloud-functions/read_source_data/requirements.txt
+++ b/cloud-functions/read_source_data/requirements.txt
@@ -11,5 +11,5 @@ google-crc32c==1.3.0
 google-resumable-media==2.3.3
 googleapis-common-protos==1.56.4
 grpc-google-iam-v1==0.12.4
-phdi==0.1.0.dev1
+phdi
 phdi_cloud_function_utils @ git+https://github.com/CDCgov/phdi-google-cloud@main#subdirectory=cloud-functions/phdi_cloud_function_utils

--- a/cloud-run/fhir-converter/Dockerfile
+++ b/cloud-run/fhir-converter/Dockerfile
@@ -1,23 +1,30 @@
-FROM python:3.10
-
-# Install dotnet
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | \
-    bash /dev/stdin -Channel 3.1 -InstallDir /usr/share/dotnet && \
-    ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
+FROM mcr.microsoft.com/dotnet/sdk:3.1 as build
 
 # Download FHIR-Converter
-WORKDIR /build
-RUN git clone https://github.com/microsoft/FHIR-Converter.git --branch v5.0.4 --single-branch
+RUN git clone https://github.com/microsoft/FHIR-Converter.git --branch v5.0.4 --single-branch /build/FHIR-Converter
 WORKDIR /build/FHIR-Converter
+RUN mkdir bin && \
+    wget https://github.com/deislabs/oras/releases/download/v0.12.0/oras_0.12.0_windows_amd64.tar.gz -O ./bin/oras.tar.gz && \
+    tar -xvf ./bin/oras.tar.gz -C ./bin
 
-# Build Microsoft FHIR Converter binary. Need to run twice due to strange error copying oras.exe
-RUN dotnet build || true
-RUN dotnet build
+# Build Microsoft FHIR Converter
+RUN dotnet build -c Release -o output
 
+FROM mcr.microsoft.com/dotnet/runtime:3.1 as runtime
+
+# Copy FHIR-Converter binary from build stage
+COPY --from=build /build/FHIR-Converter/output /build/FHIR-Converter/output
+COPY --from=build /build/FHIR-Converter/data/Templates /build/FHIR-Converter/data/Templates
+
+# Install python/pip
+ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y python3 python3-pip
+RUN pip3 install --no-cache --upgrade pip setuptools
+
+# Install requirements
 WORKDIR /app
-
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 COPY main.py .
 

--- a/cloud-run/fhir-converter/main.py
+++ b/cloud-run/fhir-converter/main.py
@@ -136,7 +136,7 @@ def convert_to_fhir(
 
     # Setup path variables
     converter_project_path = (
-        "/build/FHIR-Converter/src/Microsoft.Health.Fhir.Liquid.Converter.Tool"
+        "/build/FHIR-Converter/output/Microsoft.Health.Fhir.Liquid.Converter.Tool.dll"
     )
     if input_type == "hl7v2":
         template_directory_path = "/build/FHIR-Converter/data/Templates/Hl7v2"
@@ -154,8 +154,7 @@ def convert_to_fhir(
 
     # Formulate command for the FHIR Converter.
     fhir_conversion_command = [
-        "dotnet run ",
-        f"--project {converter_project_path} ",
+        f"dotnet {converter_project_path} ",
         "convert -- ",
         f"--TemplateDirectory {template_directory_path} ",
         f"--RootTemplate {root_template} ",


### PR DESCRIPTION
This reduces the size of the fhir-converter Docker image from 2.9 GB to 677 MB. Should hopefully speed up cold starts in the pipeline.