### PR TITLE
Increase cloud function deployment timeout

### DIFF
--- a/google-workflows/ingestion-pipeline.yaml
+++ b/google-workflows/ingestion-pipeline.yaml
@@ -80,7 +80,7 @@ main:
     - upload_fhir_bundle:
         call: http.post
         args:
-          url: https://us-west1-phdi-357418.cloudfunctions.net/phdi-dev-upload-fhir-bundle
+          url: ${upload_fhir_bundle_url}
           auth:
             type: OIDC
           body:

--- a/terraform/modules/cloud-functions/main.tf
+++ b/terraform/modules/cloud-functions/main.tf
@@ -13,6 +13,10 @@ resource "google_cloudfunctions_function" "upload-fhir-bundle" {
   environment_variables = {
     PHI_STORAGE_BUCKET = var.phi_storage_bucket
   }
+  timeouts {
+    create = "30m"
+    delete = "30m"
+  }
 }
 
 resource "google_cloudfunctions_function" "read_source_data" {
@@ -36,6 +40,10 @@ resource "google_cloudfunctions_function" "read_source_data" {
     PROJECT_ID      = var.project_id
     INGESTION_TOPIC = var.ingestion_topic
   }
+  timeouts {
+    create = "30m"
+    delete = "30m"
+  }
 }
 
 resource "google_cloudfunctions_function" "add-patient-hash" {
@@ -55,6 +63,10 @@ resource "google_cloudfunctions_function" "add-patient-hash" {
     version    = "1"
     project_id = var.project_id
   }
+  timeouts {
+    create = "30m"
+    delete = "30m"
+  }
 }
 
 resource "google_cloudfunctions_function" "standardize-names" {
@@ -68,6 +80,10 @@ resource "google_cloudfunctions_function" "standardize-names" {
   trigger_http          = true
   entry_point           = "http_standardize_names"
   service_account_email = var.workflow_service_account_email
+  timeouts {
+    create = "30m"
+    delete = "30m"
+  }
 }
 
 resource "google_cloudfunctions_function" "standardize-phones" {
@@ -81,6 +97,10 @@ resource "google_cloudfunctions_function" "standardize-phones" {
   trigger_http          = true
   entry_point           = "http_standardize_phones"
   service_account_email = var.workflow_service_account_email
+  timeouts {
+    create = "30m"
+    delete = "30m"
+  }
 }
 
 resource "google_cloudfunctions_function" "geocode-patients" {
@@ -107,6 +127,10 @@ resource "google_cloudfunctions_function" "geocode-patients" {
     version    = "1"
     project_id = var.project_id
   }
+  timeouts {
+    create = "30m"
+    delete = "30m"
+  }
 }
 
 resource "google_cloudfunctions_function" "failed_fhir_conversion" {
@@ -123,6 +147,10 @@ resource "google_cloudfunctions_function" "failed_fhir_conversion" {
 
   environment_variables = {
     PHI_STORAGE_BUCKET = var.phi_storage_bucket
+  }
+  timeouts {
+    create = "30m"
+    delete = "30m"
   }
 }
 


### PR DESCRIPTION
This PR increases the timeout time in Terraform for deploying all of our cloud functions. This should hopefully address the behavior we have now seen twice during our usability testing where the deployment workflow failed because deploying the cloud functions timed out.