### PR TITLE
Improve quick-start.sh based on Gordon's usability test

### DIFF
--- a/quick-start.sh
+++ b/quick-start.sh
@@ -290,8 +290,8 @@ echo
 
 # Watch Terraform Setup workflow until complete
 spin "Watching Terraform Setup workflow..." sleep 2
-TF_SETUP_WORKFLOW_ID=$(gh run list --workflow=terraformSetup.yaml -L 1 --json databaseId -q ".[0].databaseId")
-gh run watch $TF_SETUP_WORKFLOW_ID
+TF_SETUP_WORKFLOW_ID=$(gh -R "${GITHUB_REPO}" run list --workflow=terraformSetup.yaml -L 1 --json databaseId -q ".[0].databaseId")
+gh -R "${GITHUB_REPO}" run watch $TF_SETUP_WORKFLOW_ID
 
 # Check for Terraform Setup workflow success
 TF_SETUP_SUCCESS=$(gh -R "${GITHUB_REPO}" run list --workflow=terraformSetup.yaml --json conclusion -q '.[].conclusion')
@@ -309,8 +309,8 @@ echo
 
 # Watch deployment workflow until complete
 spin "Watching deployment workflow..." sleep 2
-DEPLOYMENT_WORKFLOW_ID=$(gh run list --workflow=deployment.yaml -L 1 --json databaseId -q ".[0].databaseId")
-gh run watch $DEPLOYMENT_WORKFLOW_ID
+DEPLOYMENT_WORKFLOW_ID=$(gh -R "${GITHUB_REPO}" run list --workflow=deployment.yaml -L 1 --json databaseId -q ".[0].databaseId")
+gh -R "${GITHUB_REPO}" run watch $DEPLOYMENT_WORKFLOW_ID
 
 # Check for deployment workflow success
 DEPLOY_SUCCESS=$(gh -R "${GITHUB_REPO}" run list --workflow=deployment.yaml --json conclusion -q '.[].conclusion')

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -289,7 +289,17 @@ spin "Starting Terraform Setup workflow..." gh -R "${GITHUB_REPO}" workflow run 
 echo
 
 # Watch Terraform Setup workflow until complete
-spin "Watching Terraform Setup workflow..." sleep 2
+TF_SETUP_STARTED=$(gh -R "${GITHUB_REPO}" run list --workflow=terraformSetup.yaml --json databaseId -q ". | length")
+CHECK_COUNT=0
+while [ "$TF_SETUP_STARTED" = "0" ]; do
+  if [ "$CHECK_COUNT" -gt 60 ]; then
+    echo "Looks like that didn't work! Please contact the PHDI team for help."
+    exit 1
+  fi
+  spin "Waiting for Terraform Setup workflow to start..." sleep 1
+  TF_SETUP_STARTED=$(gh -R "${GITHUB_REPO}" run list --workflow=terraformSetup.yaml --json databaseId -q ". | length")
+  CHECK_COUNT=$((CHECK_COUNT+1))
+done
 TF_SETUP_WORKFLOW_ID=$(gh -R "${GITHUB_REPO}" run list --workflow=terraformSetup.yaml -L 1 --json databaseId -q ".[0].databaseId")
 gh -R "${GITHUB_REPO}" run watch $TF_SETUP_WORKFLOW_ID
 
@@ -308,7 +318,17 @@ spin "Running Terraform Deploy workflow..." gh -R "${GITHUB_REPO}" workflow run 
 echo
 
 # Watch deployment workflow until complete
-spin "Watching deployment workflow..." sleep 2
+DEPLOYMENT_STARTED=$(gh -R "${GITHUB_REPO}" run list --workflow=deployment.yaml --json databaseId -q ". | length")
+CHECK_COUNT=0
+while [ "$DEPLOYMENT_STARTED" = "0" ]; do
+  if [ "$CHECK_COUNT" -gt 60 ]; then
+    echo "Looks like that didn't work! Please contact the PHDI team for help."
+    exit 1
+  fi
+  spin "Waiting for deployment workflow to start..." sleep 1
+  DEPLOYMENT_STARTED=$(gh -R "${GITHUB_REPO}" run list --workflow=deployment.yaml --json databaseId -q ". | length")
+  CHECK_COUNT=$((CHECK_COUNT+1))
+done
 DEPLOYMENT_WORKFLOW_ID=$(gh -R "${GITHUB_REPO}" run list --workflow=deployment.yaml -L 1 --json databaseId -q ".[0].databaseId")
 gh -R "${GITHUB_REPO}" run watch $DEPLOYMENT_WORKFLOW_ID
 


### PR DESCRIPTION
- [x] Add dash to `./quickstart.sh` in README.
- [x] Have script pause after instructions are printed to allow time for them to be read before pop-up windows obscure them. 
- [x] State the users will need to click the GH link 
- [x] GH may require 2 factor auth 
- [x] Define what “forking” a repo means and explain why it is necessary 
- [x] Trim options for Zone and Region to only the ones that support all resources we deploy (https://cloud.google.com/healthcare-api/docs/how-tos/datasets) 
- [x] Remove question of doing deployment; just do it 
- [x] Explore streaming GH workflow logs into QS script. 